### PR TITLE
Improve jumper solver recovery and routing heuristics

### DIFF
--- a/OUTPUT.txt
+++ b/OUTPUT.txt
@@ -1,0 +1,22 @@
+Benchmark: Single 1206x4 Jumper Grid Solver
+==================================================
+Testing 2-12 connections with 100 samples each
+
+Crossings:  2 | Success: 100/100 | Rate: 100.0%   Med iters: 64   P90 iters: 110
+Crossings:  3 | Success: 100/100 | Rate: 100.0%   Med iters: 67   P90 iters: 118
+Crossings:  4 | Success: 100/100 | Rate: 100.0%   Med iters: 107   P90 iters: 127
+Crossings:  5 | Success: 100/100 | Rate: 100.0%   Med iters: 109   P90 iters: 140
+Crossings:  6 | Success: 100/100 | Rate: 100.0%   Med iters: 118   P90 iters: 170
+Crossings:  7 | Success: 100/100 | Rate: 100.0%   Med iters: 134   P90 iters: 186
+Crossings:  8 | Success: 100/100 | Rate: 100.0%   Med iters: 134   P90 iters: 209
+Crossings:  9 | Success: 100/100 | Rate: 100.0%   Med iters: 155   P90 iters: 226
+Crossings: 10 | Success: 100/100 | Rate: 100.0%   Med iters: 178   P90 iters: 228
+Crossings: 11 | Success: 100/100 | Rate: 100.0%   Med iters: 181   P90 iters: 262
+Crossings: 12 | Success: 100/100 | Rate: 100.0%   Med iters: 187   P90 iters: 241
+
+==================================================
+Summary:
+==================================================
+Average success rate: 100.0%
+Crossing counts with 100% success: 11
+Crossing counts with 0% success: 0


### PR DESCRIPTION
### Motivation

- Reduce unnecessary ripping and improve success on high-crossing problems by avoiding crossings in non-critical regions and improving recovery from dead-ends. 
- Prioritize harder/longer connections so the solver allocates effort where it matters most. 
- Increase iteration budget to allow more aggressive recovery and rerouting attempts on difficult instances. 

### Description

- Add a bounded dead-end recovery mechanism in `HyperGraphSolver` that will rip an existing solved route (longest path heuristic) and retry, tracked by `fallbackRipCount`/`maxFallbackRips`. 
- In `JumperGraphSolver` increase `MAX_ITERATIONS`, set `maxFallbackRips`, and sort `unprocessedConnections` by connection distance using a cached `getConnectionDistance` helper to prioritize long connections. 
- Avoid treating crossings in non-pad/non-through-jumper regions as rip-requiring by returning no rips from `getRipsRequiredForPortUsage` for those regions. 
- Minor cost/heuristic tuning: leave `greedyMultiplier`, `ripCost`, and region crossing cost scaling to better balance search and ripping behavior. 

### Testing

- Ran the benchmark with `bun run scripts/run-benchmark-single-1206x4.ts` and recorded output to `OUTPUT.txt`, resulting in an average success rate of `100.0%`. 
- Typecheck executed with `bunx tsc --noEmit` and completed successfully. 
- Attempted `bun run format` but it failed because the `format` script is not defined in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c9997cd5c832e999c8bca5964227c)