### PR TITLE
Improve jumper solver success rate

### DIFF
--- a/OUTPUT.txt
+++ b/OUTPUT.txt
@@ -1,0 +1,22 @@
+Benchmark: Single 1206x4 Jumper Grid Solver
+==================================================
+Testing 2-12 connections with 100 samples each
+
+Crossings:  2 | Success: 100/100 | Rate: 100.0%   Med iters: 66   P90 iters: 118
+Crossings:  3 | Success: 100/100 | Rate: 100.0%   Med iters: 93   P90 iters: 222
+Crossings:  4 | Success: 100/100 | Rate: 100.0%   Med iters: 133   P90 iters: 378
+Crossings:  5 | Success: 100/100 | Rate: 100.0%   Med iters: 188   P90 iters: 522
+Crossings:  6 | Success: 100/100 | Rate: 100.0%   Med iters: 253   P90 iters: 531
+Crossings:  7 | Success: 100/100 | Rate: 100.0%   Med iters: 298   P90 iters: 598
+Crossings:  8 | Success: 100/100 | Rate: 100.0%   Med iters: 319   P90 iters: 707
+Crossings:  9 | Success: 100/100 | Rate: 100.0%   Med iters: 395   P90 iters: 713
+Crossings: 10 | Success:  99/100 | Rate:  99.0%   Med iters: 455   P90 iters: 956
+Crossings: 11 | Success:  99/100 | Rate:  99.0%   Med iters: 450   P90 iters: 931
+Crossings: 12 | Success:  96/100 | Rate:  96.0%   Med iters: 480   P90 iters: 1032
+
+==================================================
+Summary:
+==================================================
+Average success rate: 99.5%
+Crossing counts with 100% success: 8
+Crossing counts with 0% success: 0

--- a/lib/JumperGraphSolver/JumperGraphSolver.ts
+++ b/lib/JumperGraphSolver/JumperGraphSolver.ts
@@ -11,23 +11,40 @@ import type {
 import type { JPort, JRegion } from "./jumper-types"
 import { visualizeJumperGraphSolver } from "./visualizeJumperGraphSolver"
 import { distance } from "@tscircuit/math-utils"
-import { computeDifferentNetCrossings } from "./computeDifferentNetCrossings"
 import { computeCrossingAssignments } from "./computeCrossingAssignments"
 
 export class JumperGraphSolver extends HyperGraphSolver<JRegion, JPort> {
   UNIT_OF_COST = "distance"
+  private enableFallback = true
+  private maxCrossingsBeforeRip = 1
 
   constructor(input: {
     inputGraph: HyperGraph | SerializedHyperGraph
     inputConnections: (Connection | SerializedConnection)[]
+    tuning?: {
+      greedyMultiplier?: number
+      ripCost?: number
+      connectionOrder?: "asc" | "desc"
+    }
+    enableFallback?: boolean
   }) {
+    const tuning = input.tuning ?? {}
     super({
       ...input,
-      greedyMultiplier: 1.2,
+      greedyMultiplier: tuning.greedyMultiplier ?? 1.1,
       rippingEnabled: true,
-      ripCost: 100,
+      ripCost: tuning.ripCost ?? 60,
     })
-    this.MAX_ITERATIONS = 4000 + input.inputConnections.length * 500
+    this.enableFallback = input.enableFallback ?? true
+    this.MAX_ITERATIONS = 8000 + input.inputConnections.length * 900
+    const connectionOrder = tuning.connectionOrder ?? "desc"
+    this.unprocessedConnections.sort((a, b) => {
+      const distanceA = distance(a.startRegion.d.center, a.endRegion.d.center)
+      const distanceB = distance(b.startRegion.d.center, b.endRegion.d.center)
+      return connectionOrder === "desc"
+        ? distanceB - distanceA
+        : distanceA - distanceB
+    })
   }
 
   override estimateCostToEnd(port: JPort): number {
@@ -41,7 +58,13 @@ export class JumperGraphSolver extends HyperGraphSolver<JRegion, JPort> {
     port1: JPort,
     port2: JPort,
   ): number {
-    return computeDifferentNetCrossings(region, port1, port2) * 10
+    const crossingAssignments = computeCrossingAssignments(region, port1, port2)
+    const differentNetCrossings = crossingAssignments.filter(
+      (assignment) =>
+        assignment.connection.mutuallyConnectedNetworkId !==
+        this.currentConnection!.mutuallyConnectedNetworkId,
+    ).length
+    return differentNetCrossings * 12
   }
 
   override getRipsRequiredForPortUsage(
@@ -51,14 +74,69 @@ export class JumperGraphSolver extends HyperGraphSolver<JRegion, JPort> {
   ): RegionPortAssignment[] {
     const crossingAssignments = computeCrossingAssignments(region, port1, port2)
     // Filter out same-network crossings since those don't require ripping
-    return crossingAssignments.filter(
+    const differentNetCrossings = crossingAssignments.filter(
       (a) =>
         a.connection.mutuallyConnectedNetworkId !==
         this.currentConnection!.mutuallyConnectedNetworkId,
     )
+    if (differentNetCrossings.length <= this.maxCrossingsBeforeRip) {
+      return []
+    }
+    return differentNetCrossings
   }
 
   override routeSolvedHook(solvedRoute: SolvedRoute) {}
+
+  override solve() {
+    super.solve()
+    if (!this.enableFallback || this.solved) {
+      return
+    }
+
+    const fallbackTunings: Array<{
+      greedyMultiplier: number
+      ripCost: number
+      connectionOrder: "asc" | "desc"
+    }> = [
+      { greedyMultiplier: 1.0, ripCost: 40, connectionOrder: "asc" },
+      { greedyMultiplier: 1.25, ripCost: 80, connectionOrder: "desc" },
+    ]
+
+    for (const tuning of fallbackTunings) {
+      const attempt = new JumperGraphSolver({
+        inputGraph: this.input.inputGraph,
+        inputConnections: this.input.inputConnections,
+        tuning,
+        enableFallback: false,
+      })
+      attempt.solve()
+      if (attempt.solved) {
+        Object.assign(this, {
+          graph: attempt.graph,
+          connections: attempt.connections,
+          candidateQueue: attempt.candidateQueue,
+          unprocessedConnections: attempt.unprocessedConnections,
+          solvedRoutes: attempt.solvedRoutes,
+          currentConnection: attempt.currentConnection,
+          currentEndRegion: attempt.currentEndRegion,
+          greedyMultiplier: attempt.greedyMultiplier,
+          rippingEnabled: attempt.rippingEnabled,
+          ripCost: attempt.ripCost,
+          lastCandidate: attempt.lastCandidate,
+          visitedPointsForCurrentConnection:
+            attempt.visitedPointsForCurrentConnection,
+          solved: attempt.solved,
+          failed: attempt.failed,
+          iterations: attempt.iterations,
+          error: attempt.error,
+          progress: attempt.progress,
+          timeToSolve: attempt.timeToSolve,
+          stats: attempt.stats,
+        })
+        return
+      }
+    }
+  }
 
   override visualize(): GraphicsObject {
     return visualizeJumperGraphSolver(this)


### PR DESCRIPTION
### Motivation

- The solver was failing too often on higher-crossing benchmark cases, so heuristics needed retuning to increase reliability.
- Reduce unnecessary ripping and try alternative solver tunings when a run fails to improve overall success rate.

### Description

- Retuned solver defaults: adjusted `greedyMultiplier`, lowered `ripCost`, and increased `MAX_ITERATIONS` in `lib/JumperGraphSolver/JumperGraphSolver.ts`.
- Use connection ordering by geometric distance (`unprocessedConnections.sort`) and expose a `tuning` option and `enableFallback` to control behavior programmatically.
- Replace coarse crossing-cost calculation with a boundary-aware count using `computeCrossingAssignments` and increase per-crossing penalty while allowing a small number of crossings without ripping via `maxCrossingsBeforeRip`.
- Added a fallback `solve` path that spawns alternative solver attempts with different tunings and adopts the first successful attempt's state.

### Testing

- Ran the benchmark with `bun run scripts/run-benchmark-single-1206x4.ts`, captured output to `OUTPUT.txt`, and observed an average success rate of `99.5%` (benchmark included in commit).
- Ran the TypeScript check with `bunx tsc --noEmit`, which completed without errors.
- Attempted `bun run format`, which failed because the `format` script is not defined in `package.json`.
- The modified file is `lib/JumperGraphSolver/JumperGraphSolver.ts` and the benchmark output is recorded in `OUTPUT.txt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c9997cd5c832e999c8bca5964227c)