### PR TITLE
Tune JumperGraphSolver heuristics and iteration budget to reach 60% benchmark success

### DIFF
--- a/OUTPUT.txt
+++ b/OUTPUT.txt
@@ -1,0 +1,22 @@
+Benchmark: Single 1206x4 Jumper Grid Solver
+==================================================
+Testing 2-12 connections with 100 samples each
+
+Crossings:  2 | Success:  99/100 | Rate:  99.0%   Med iters: 258   P90 iters: 661
+Crossings:  3 | Success: 100/100 | Rate: 100.0%   Med iters: 206   P90 iters: 493
+Crossings:  4 | Success:  92/100 | Rate:  92.0%   Med iters: 375   P90 iters: 662
+Crossings:  5 | Success:  97/100 | Rate:  97.0%   Med iters: 325   P90 iters: 756
+Crossings:  6 | Success:  82/100 | Rate:  82.0%   Med iters: 280   P90 iters: 745
+Crossings:  7 | Success:  55/100 | Rate:  55.0%   Med iters: 409   P90 iters: 827
+Crossings:  8 | Success:  59/100 | Rate:  59.0%   Med iters: 404   P90 iters: 991
+Crossings:  9 | Success:  40/100 | Rate:  40.0%   Med iters: 422   P90 iters: 1000
+Crossings: 10 | Success:  16/100 | Rate:  16.0%   Med iters: 273   P90 iters: 391
+Crossings: 11 | Success:  16/100 | Rate:  16.0%   Med iters: 372   P90 iters: 838
+Crossings: 12 | Success:   4/100 | Rate:   4.0%   Med iters: 1159   P90 iters: 1159
+
+==================================================
+Summary:
+==================================================
+Average success rate: 60.0%
+Crossing counts with 100% success: 1
+Crossing counts with 0% success: 0

--- a/lib/JumperGraphSolver/JumperGraphSolver.ts
+++ b/lib/JumperGraphSolver/JumperGraphSolver.ts
@@ -23,25 +23,25 @@ export class JumperGraphSolver extends HyperGraphSolver<JRegion, JPort> {
   }) {
     super({
       ...input,
-      greedyMultiplier: 1.2,
+      greedyMultiplier: 0.95,
       rippingEnabled: true,
-      ripCost: 100,
+      ripCost: 40,
     })
-    this.MAX_ITERATIONS = 4000 + input.inputConnections.length * 500
+    this.MAX_ITERATIONS = 20000 + input.inputConnections.length * 1500
   }
 
   override estimateCostToEnd(port: JPort): number {
     return distance(port.d, this.currentEndRegion!.d.center)
   }
   override getPortUsagePenalty(port: JPort): number {
-    return (port.ripCount ?? 0) * 2
+    return (port.ripCount ?? 0) * 1
   }
   override computeIncreasedRegionCostIfPortsAreUsed(
     region: JRegion,
     port1: JPort,
     port2: JPort,
   ): number {
-    return computeDifferentNetCrossings(region, port1, port2) * 10
+    return computeDifferentNetCrossings(region, port1, port2) * 6
   }
 
   override getRipsRequiredForPortUsage(


### PR DESCRIPTION
### Motivation

- Improve success rate of the Single 1206x4 Jumper Grid Solver benchmark to at least 60% by adjusting solver heuristics and budgets.  
- Reduce unnecessary ripping penalties and better balance exploration vs heuristic guidance for high-crossing cases.  
- Provide a reproducible benchmark output capture for verification.  

### Description

- Adjust solver heuristic and costs by setting `greedyMultiplier` to `0.95`, `ripCost` to `40`, and reducing port rip penalty to `1`.  
- Lower per-crossing penalty to `computeDifferentNetCrossings(...) * 6` and increase `MAX_ITERATIONS` to `20000 + input.inputConnections.length * 1500`.  
- Add `OUTPUT.txt` containing the benchmark run output and commit the updated `lib/JumperGraphSolver/JumperGraphSolver.ts`.  

### Testing

- Ran `bun run scripts/run-benchmark-single-1206x4.ts` and observed an average success rate of `60.0%` (output saved to `OUTPUT.txt`).  
- Ran `bunx tsc --noEmit` for type checking which completed successfully.  
- Attempted `bun run format` which failed because the `format` script is not present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c9997cd5c832e999c8bca5964227c)